### PR TITLE
chore(ci): drop informational Trivy fs scan (no image to migrate to grype)

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -178,17 +178,6 @@ jobs:
         if: always()
         continue-on-error: true  # Don't fail if GitHub Advanced Security is not enabled
 
-      - name: Run Trivy vulnerability scanner
-        uses: aquasecurity/trivy-action@master
-        with:
-          scan-type: 'fs'
-          scan-ref: '.'
-          format: 'table'
-          exit-code: '0'
-          ignore-unfixed: true
-          vuln-type: 'os,library'
-          severity: 'CRITICAL,HIGH'
-
   e2e:
     name: E2E Tests
     runs-on: ubuntu-latest


### PR DESCRIPTION
## Summary
- Removes the "Run Trivy vulnerability scanner" step from `ci.yaml`'s `security` job.
- This Trivy step was an **informational, non-blocking** filesystem/source scan (`scan-type: fs`, `scan-ref: .`, `exit-code: 0`) — it never gated CI and never scanned a container image.
- This repo does not publish images to Harbor (`harbor.support.tools`); the build/release jobs push only to `ghcr.io`. The org-wide `SupportTools/ci-runners/.github/workflows/grype-scan.yml@main` reusable workflow scans **container images**, so there is nothing here for it to scan/replace.
- Per the migration guidance, an image-less fs scan with no Harbor target is **dropped** rather than migrated to grype.
- No `.trivyignore` existed, so no `.grype.yaml` was needed.
- Gosec (SARIF, `-no-fail`, non-blocking) is untouched and remains the source-level security scan for this repo.

## Test plan
- [x] `python3 -c 'import yaml; yaml.safe_load(open(".github/workflows/ci.yaml"))'` succeeds
- [x] No remaining `trivy` references anywhere under `.github/workflows/`
- [ ] CI checks pass on this PR (lint/test/build/helm/security jobs unaffected by removal)